### PR TITLE
Feature/interlok 3765 add licensed info column

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,37 @@
+name: Java CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Setup Ubuntu
+      run: |
+        sudo apt-get -y update
+        sudo apt-get -y install haveged
+        sudo systemctl enable haveged
+        sudo systemctl restart haveged
+    - name: Gradle Wrapper Cache
+      uses: actions/cache@v1
+      with:
+        path: ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle-wrapper.properties') }}
+    - name: Gradle Dependencies Cache
+      uses: actions/cache@v1
+      with:
+        path: ~/.gradle/caches
+        key: ${{ runner.os }}-gradle-cache-${{ hashFiles('**/*.gradle') }}
+    - name: Gradle Test
+      run: |
+        ./gradlew -Djava.security.egd=file:/dev/./urandom -Dorg.gradle.console=plain --no-daemon -PverboseTests=true check
+    - name: codecov.io
+      uses: codecov/codecov-action@v1

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ The simple jar, the uber jar and the targeted platform archive will be published
 $ ./gradlew clean publish -PtargetPlatform=(win|linux|mac)
 ```
 
+## Test
+
+```
+$ ./gradlew clean check
+```
+
 ## Additional configuration
 
 All the base configuration is stored in `src/main/resources/installer.properties` which can be overriden either at build time; or via system properties on startup.

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ repositories {
 }
 
 dependencies {
-  implementation "org.gradle:gradle-tooling-api:6.8.1"
+  implementation "org.gradle:gradle-tooling-api:5.6.4"
   
   runtimeOnly "org.openjfx:javafx-base:$javafxVersion:$targetPlatform"
   runtimeOnly "org.openjfx:javafx-graphics:$javafxVersion:$targetPlatform"

--- a/build.gradle
+++ b/build.gradle
@@ -158,4 +158,12 @@ publishing {
   }
 }
 
+task initCompileOnlyConfiguration {
+  doLast {
+    javafx.configuration = "compile"
+  }
+}
+
+
+check.dependsOn initCompileOnlyConfiguration
 check.dependsOn jacocoTestReport

--- a/src/main/java/com/adaptris/installer/OptionalComponentCell.java
+++ b/src/main/java/com/adaptris/installer/OptionalComponentCell.java
@@ -3,6 +3,8 @@ package com.adaptris.installer;
 import java.io.InputStream;
 import java.util.Objects;
 
+import org.gradle.internal.impldep.org.apache.commons.lang.BooleanUtils;
+
 import com.adaptris.installer.models.OptionalComponent;
 
 import javafx.beans.property.SimpleBooleanProperty;
@@ -17,17 +19,21 @@ public class OptionalComponentCell {
   public static final String ARTIFACT_LOGO_DEFAULT = "default.png";
 
   private OptionalComponent optionalComponent;
+  private StringProperty id;
   private StringProperty name;
   private StringProperty description;
   private StringProperty tags;
+  private SimpleBooleanProperty licensed;
   private SimpleBooleanProperty selected;
   private ImageView icon;
 
   public OptionalComponentCell(OptionalComponent optionalComponent) {
     this.optionalComponent = optionalComponent;
+    id = new SimpleStringProperty(optionalComponent, "id", optionalComponent.getId());
     name = new SimpleStringProperty(optionalComponent, "name", optionalComponent.getName());
     description = new SimpleStringProperty(optionalComponent, "description", optionalComponent.getDescription());
     tags = new SimpleStringProperty(optionalComponent, "tags", optionalComponent.getTags());
+    licensed = new SimpleBooleanProperty(BooleanUtils.toBoolean(optionalComponent.getLicense()));
     selected = new SimpleBooleanProperty(false);
     icon = new ImageView(getImage(optionalComponent));
   }
@@ -38,6 +44,18 @@ public class OptionalComponentCell {
       iconStream = getClass().getResourceAsStream(ARTIFACT_LOGO_BASE + ARTIFACT_LOGO_DEFAULT);
     }
     return new Image(iconStream, 30, 30, true, true);
+  }
+
+  public String getId() {
+    return idProperty().get();
+  }
+
+  public void setId(String id) {
+    idProperty().set(id);
+  }
+
+  public StringProperty idProperty() {
+    return id;
   }
 
   public String getName() {
@@ -74,6 +92,18 @@ public class OptionalComponentCell {
 
   public StringProperty tagsProperty() {
     return tags;
+  }
+
+  public Boolean getLicensed() {
+    return licensedProperty().get();
+  }
+
+  public void setLicensed(Boolean licensed) {
+    licensedProperty().set(licensed);
+  }
+
+  public SimpleBooleanProperty licensedProperty() {
+    return licensed;
   }
 
   public Boolean getSelected() {

--- a/src/main/java/com/adaptris/installer/controllers/OptionalComponentsController.java
+++ b/src/main/java/com/adaptris/installer/controllers/OptionalComponentsController.java
@@ -42,6 +42,8 @@ public class OptionalComponentsController extends CancelAwareInstallerController
   @FXML
   private TableColumn<OptionalComponentCell, String> tagsColumn;
   @FXML
+  private TableColumn<OptionalComponentCell, Boolean> licensedColumn;
+  @FXML
   private TableColumn<OptionalComponentCell, Boolean> selectColumn;
 
   private final List<OptionalComponentCell> optionalComponentCells = new ArrayList<>();
@@ -51,6 +53,13 @@ public class OptionalComponentsController extends CancelAwareInstallerController
    */
   @FXML
   private void initialize() {
+    licensedColumn.setCellFactory(tc -> {
+      CheckBoxTableCell<OptionalComponentCell, Boolean> cell = new CheckBoxTableCell<>();
+      cell.setAlignment(Pos.CENTER);
+      cell.setDisable(true);
+      cell.getStyleClass().add("licensed-cell");
+      return cell;
+    });
     selectColumn.setCellFactory(tc -> {
       CheckBoxTableCell<OptionalComponentCell, Boolean> cell = new CheckBoxTableCell<>();
       cell.setAlignment(Pos.CENTER);

--- a/src/main/java/com/adaptris/installer/utils/FxUtils.java
+++ b/src/main/java/com/adaptris/installer/utils/FxUtils.java
@@ -21,7 +21,7 @@ public class FxUtils {
 
   public static String getIdOrName(OptionalComponentCell occ, String name) {
     if (occ != null) {
-      return occ.getOptionalComponent().getId();
+      return occ.getId();
     }
     return name;
   }

--- a/src/main/resources/css/optional_components.css
+++ b/src/main/resources/css/optional_components.css
@@ -9,3 +9,8 @@
 .optional-components .table-view .placeholder .label {
     -fx-text-fill: #333333;
 }
+
+.licensed-cell > .check-box .box {
+    -fx-background-color: transparent;
+    -fx-border-color: transparent;
+}

--- a/src/main/resources/views/optional_components.fxml
+++ b/src/main/resources/views/optional_components.fxml
@@ -14,79 +14,84 @@
 <VBox fx:controller="com.adaptris.installer.controllers.OptionalComponentsController" 
     xmlns:fx="http://javafx.com/fxml" styleClass="optional-components" spacing="10">
     
-	<padding><Insets top="20" right="20" bottom="20" left="20"/></padding>
-	
-	<children>
+  <padding><Insets top="20" right="20" bottom="20" left="20"/></padding>
+  
+  <children>
     <HBox styleClass="page-logo">
       <padding><Insets top="50" bottom="10" /></padding>
     </HBox>
-		<Label text="Optional Components Selection"></Label>
-		<VBox prefHeight="425" spacing="10" alignment="center" >
-		
-			<padding><Insets top="0" bottom="0" /></padding>
-			
-			<children>
-			
-				<VBox spacing="10" styleClass="">
-					<children>
-						<HBox spacing="5" prefWidth="750" styleClass="filter-text">
-							<children>
-								<Label text="Filter"></Label>
-								<TextField fx:id="filterTextField" text="" promptText="Filter"></TextField>
-							</children>
-						</HBox>
+    <Label text="Optional Components Selection"></Label>
+    <VBox prefHeight="425" spacing="10" alignment="center" >
+    
+      <padding><Insets top="0" bottom="0" /></padding>
+      
+      <children>
+      
+        <VBox spacing="10" styleClass="">
+          <children>
+            <HBox spacing="5" prefWidth="750" styleClass="filter-text">
+              <children>
+                <Label text="Filter"></Label>
+                <TextField fx:id="filterTextField" text="" promptText="Filter"></TextField>
+              </children>
+            </HBox>
 
-						<TableView fx:id="tableView" editable="true" prefWidth="750" prefHeight="390" GridPane.columnIndex="0" GridPane.rowIndex="1">
-							<columns>
-								<TableColumn fx:id="iconColumn" minWidth="40" maxWidth="40" reorderable="false" sortable="false" text="Icon">
-					        <cellValueFactory>
-					        	<PropertyValueFactory property="icon" />
-				        	</cellValueFactory>
-								</TableColumn>
-								<TableColumn fx:id="selectColumn" minWidth="70" maxWidth="70" sortable="false" text="Select">
-					        <cellValueFactory>
-					        	<PropertyValueFactory property="selected" />
-				        	</cellValueFactory>
-								</TableColumn>
-								<TableColumn fx:id="nameColumn" minWidth="160" maxWidth="400" text="Name">
-					        <cellValueFactory>
-					        	<PropertyValueFactory property="name" />
-				        	</cellValueFactory>
-								</TableColumn>
-								<TableColumn fx:id="descriptionColumn" minWidth="275" maxWidth="500" text="Description">
-					        <cellValueFactory>
-					        	<PropertyValueFactory property="description" />
-				        	</cellValueFactory>
-								</TableColumn>
-								<TableColumn fx:id="tagsColumn" minWidth="150" maxWidth="400" sortable="false" text="Tags">
-					        <cellValueFactory>
-					        	<PropertyValueFactory property="tags" />
-				        	</cellValueFactory>
-								</TableColumn>
-							</columns>
-							<items>
-						    <FXCollections fx:factory="observableArrayList">
-						    </FXCollections>
-							</items>
-							<placeholder>
-								<Label text="No Interlok optional components could be loaded"></Label>
-							</placeholder>
-						</TableView>
-				
-					</children>
-				</VBox>
-			</children>
-		</VBox>
-		<HBox spacing="10" alignment="center_right">
-			<children>
-				<Button text="Cancel" onAction="#handleCancel"></Button>
-				<Button text="Previous" onAction="#handlePrevious"></Button>
-				<Button text="Install" onAction="#handleInstallInterlok"></Button>
-			</children>
-		</HBox>
-	</children>
-	<stylesheets>
-		<URL value="@/css/optional_components.css" />
-	</stylesheets>
+            <TableView fx:id="tableView" editable="true" prefWidth="750" prefHeight="390" GridPane.columnIndex="0" GridPane.rowIndex="1">
+              <columns>
+                <TableColumn fx:id="iconColumn" minWidth="40" maxWidth="40" reorderable="false" sortable="false" text="Icon">
+                  <cellValueFactory>
+                    <PropertyValueFactory property="icon" />
+                  </cellValueFactory>
+                </TableColumn>
+                <TableColumn fx:id="selectColumn" minWidth="65" maxWidth="65" sortable="false" text="Select">
+                  <cellValueFactory>
+                    <PropertyValueFactory property="selected" />
+                  </cellValueFactory>
+                </TableColumn>
+                <TableColumn fx:id="nameColumn" minWidth="150" maxWidth="400" text="Name">
+                  <cellValueFactory>
+                    <PropertyValueFactory property="name" />
+                  </cellValueFactory>
+                </TableColumn>
+                <TableColumn fx:id="descriptionColumn" minWidth="255" maxWidth="500" text="Description">
+                  <cellValueFactory>
+                    <PropertyValueFactory property="description" />
+                  </cellValueFactory>
+                </TableColumn>
+                <TableColumn fx:id="tagsColumn" minWidth="120" maxWidth="400" sortable="false" text="Tags">
+                  <cellValueFactory>
+                    <PropertyValueFactory property="tags" />
+                  </cellValueFactory>
+                </TableColumn>
+                <TableColumn fx:id="licensedColumn" minWidth="60" maxWidth="60" sortable="false" text="Licensed">
+                  <cellValueFactory>
+                    <PropertyValueFactory property="licensed" />
+                  </cellValueFactory>
+                </TableColumn>
+              </columns>
+              <items>
+                <FXCollections fx:factory="observableArrayList">
+                </FXCollections>
+              </items>
+              <placeholder>
+                <Label text="No Interlok optional components could be loaded"></Label>
+              </placeholder>
+            </TableView>
+        
+          </children>
+        </VBox>
+      </children>
+    </VBox>
+    <HBox spacing="10" alignment="center_right">
+      <children>
+        <Button text="Cancel" onAction="#handleCancel"></Button>
+        <Button text="Previous" onAction="#handlePrevious"></Button>
+        <Button text="Install" onAction="#handleInstallInterlok"></Button>
+      </children>
+    </HBox>
+  </children>
+  <stylesheets>
+    <URL value="@/css/optional_components.css" />
+  </stylesheets>
 </VBox>
 

--- a/src/test/java/com/adaptris/installer/OptionalComponentCellTest.java
+++ b/src/test/java/com/adaptris/installer/OptionalComponentCellTest.java
@@ -17,10 +17,12 @@ public class OptionalComponentCellTest {
     OptionalComponent optionalComponent = TestUtils.buildOptionalComponent();
     OptionalComponentCell optionalComponentCell = new OptionalComponentCell(optionalComponent);
 
+    assertEquals(optionalComponent.getId(), optionalComponentCell.getId());
     assertEquals(optionalComponent.getName(), optionalComponentCell.getName());
     assertEquals(optionalComponent.getDescription(), optionalComponentCell.getDescription());
     assertEquals(optionalComponent.getTags(), optionalComponentCell.getTags());
     assertNotNull(optionalComponentCell.getIcon());
+    assertFalse(optionalComponentCell.getLicensed());
     assertEquals(optionalComponent, optionalComponentCell.getOptionalComponent());
   }
 
@@ -31,6 +33,15 @@ public class OptionalComponentCellTest {
     OptionalComponentCell optionalComponentCell = new OptionalComponentCell(optionalComponent);
 
     assertNotNull(optionalComponentCell.getIcon());
+  }
+
+  @Test
+  public void testSetId() {
+    OptionalComponent optionalComponent = TestUtils.buildOptionalComponent();
+    OptionalComponentCell optionalComponentCell = new OptionalComponentCell(optionalComponent);
+    optionalComponentCell.setId("new-id");
+
+    assertEquals("new-id", optionalComponentCell.getId());
   }
 
   @Test
@@ -58,6 +69,23 @@ public class OptionalComponentCellTest {
     optionalComponentCell.setTags("New Tags");
 
     assertEquals("New Tags", optionalComponentCell.getTags());
+  }
+
+  @Test
+  public void testLicensed() {
+    OptionalComponent optionalComponent = TestUtils.buildOptionalComponent();
+    OptionalComponentCell optionalComponentCell = new OptionalComponentCell(optionalComponent);
+
+    assertFalse(optionalComponentCell.getLicensed());
+
+    optionalComponentCell.setLicensed(true);
+
+    assertTrue(optionalComponentCell.getLicensed());
+
+    optionalComponent.setLicense("true");
+    optionalComponentCell = new OptionalComponentCell(optionalComponent);
+
+    assertTrue(optionalComponentCell.getLicensed());
   }
 
   @Test


### PR DESCRIPTION
## Motivation

To make it easier for user to know which optional components require a license

## Modification

- Add a new licensed column in the optional component list. The components requiring a license will have a check in this new column.
- Add tests
- Override the javafx.configuration to "compile" instead of "compileOnly" when running the tests as it's needed to get the tests working.
- Revert back the gradle version used by the installer. The reason is that gradle 6.x changed the way it works with optional depedencies. It treats transitive optional dependencies like any other transitive dependencies and therefore will fail if the dependencies doesn't exist. For the installer, at least for now, we don't want the install to fail because of private jars.

## Result

The installer will display which optional components are licensed in a new column.
The installer will not fail to install Interlok when an optional dependencies is not available,.

## Testing

`gradlew clean check` should work

When running the installer you should see a new column with a tick for licensed optional components.
Installing optional components with private jar (tibco, sonicmq, ...) should not fail even if you didn't provide an additional nexus url. However the private jars are not installed.

