### PR TITLE
INTERLOK-3803 Make start-interlok executable on non windows platforms

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 ext {
-  releaseVersion = project.findProperty("releaseVersion") ?: "4.0-SNAPSHOT"
+  releaseVersion = project.findProperty("releaseVersion") ?: "4.1-SNAPSHOT"
   nexusBaseUrl = project.findProperty("nexusBaseUrl") ?: "https://nexus.adaptris.net/nexus"
   mavenPublishUrl = project.findProperty("mavenPublishUrl") ?: nexusBaseUrl + "/content/repositories/snapshots"
   javadocsBaseUrl = nexusBaseUrl + "/content/sites/javadocs/com/adaptris"

--- a/src/main/resources/templates/build.gradle.template
+++ b/src/main/resources/templates/build.gradle.template
@@ -1,5 +1,3 @@
-import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
-
 plugins {
   id "de.undercouch.download" version "4.0.2"
 }
@@ -7,8 +5,8 @@ plugins {
 ext {
   interlokVersion = project.hasProperty("interlokVersion") ? project.getProperty("interlokVersion") : "NEED interlokVersion PROPERTY"
   interlokUiVersion = interlokVersion
-   
-  interlokParentGradle = "https://raw.githubusercontent.com/adaptris-labs/interlok-build-parent/1.6.0/build.gradle"
+
+  interlokParentGradle = "https://raw.githubusercontent.com/adaptris/interlok-build-parent/main/v4/build.gradle"
 
   latestBaseFilesystemUrl = "https://development.adaptris.net/installers/interlok/latest-stable/base-filesystem.zip"
   interlokBaseFilesystemUrl = project.findProperty("interlokBaseFilesystemUrl") ?: latestBaseFilesystemUrl
@@ -48,25 +46,13 @@ task downloadAndUnzipFile(dependsOn: downloadBaseFilesystemZip, type: Copy) {
   into file(srcInterlokDir)
 }
 
-def chmodExec(path) {
-  project.exec {
-    commandLine("chmod", "+x", path)
-  }
-}
-
 // Do we need that or the previous step is enough?
 task downloadAndUnzipFileAndCopyConfigDir(dependsOn: downloadAndUnzipFile, type: Copy) {
   from file(srcInterlokDir + "config/")
   into interlokTmpConfigDirectory
-  
+
   doLast {
-    if (!DefaultNativePlatform.getCurrentOperatingSystem().isWindows()) {
-      from fileTree(srcInterlokDir) {
-        include "bin/start-interlok"
-      }.each {
-        chmodExec(it.path)
-      }
-    }
+    ant.chmod(file: "$srcInterlokDir/bin/start-interlok", perm: "+x")
   }
 }
 

--- a/src/main/resources/templates/build.gradle.template
+++ b/src/main/resources/templates/build.gradle.template
@@ -6,7 +6,7 @@ ext {
   interlokVersion = project.hasProperty("interlokVersion") ? project.getProperty("interlokVersion") : "NEED interlokVersion PROPERTY"
   interlokUiVersion = interlokVersion
 
-  interlokParentGradle = "https://raw.githubusercontent.com/adaptris/interlok-build-parent/main/v4/build.gradle"
+  interlokParentGradle = "https://raw.githubusercontent.com/adaptris-labs/interlok-build-parent/1.6.0/build.gradle"
 
   latestBaseFilesystemUrl = "https://development.adaptris.net/installers/interlok/latest-stable/base-filesystem.zip"
   interlokBaseFilesystemUrl = project.findProperty("interlokBaseFilesystemUrl") ?: latestBaseFilesystemUrl

--- a/src/main/resources/templates/build.gradle.template
+++ b/src/main/resources/templates/build.gradle.template
@@ -1,3 +1,5 @@
+import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
+
 plugins {
   id "de.undercouch.download" version "4.0.2"
 }
@@ -46,10 +48,26 @@ task downloadAndUnzipFile(dependsOn: downloadBaseFilesystemZip, type: Copy) {
   into file(srcInterlokDir)
 }
 
+def chmodExec(path) {
+  project.exec {
+    commandLine("chmod", "+x", path)
+  }
+}
+
 // Do we need that or the previous step is enough?
 task downloadAndUnzipFileAndCopyConfigDir(dependsOn: downloadAndUnzipFile, type: Copy) {
   from file(srcInterlokDir + "config/")
   into interlokTmpConfigDirectory
+  
+  doLast {
+    if (!DefaultNativePlatform.getCurrentOperatingSystem().isWindows()) {
+      from fileTree(srcInterlokDir) {
+        include "bin/start-interlok"
+      }.each {
+        chmodExec(it.path)
+      }
+    }
+  }
 }
 
 assemble.dependsOn downloadAndUnzipFileAndCopyConfigDir

--- a/src/test/java/com/adaptris/installer/helpers/InterlokInstallerTest.java
+++ b/src/test/java/com/adaptris/installer/helpers/InterlokInstallerTest.java
@@ -24,7 +24,7 @@ public class InterlokInstallerTest {
     interlokProject.setDirectory(interlokProjectPath.toAbsolutePath().toString());
     // We can use this line when we get a 4.0.0-RELEASE version
     // interlokProject.setVersion(TestUtils.INTERLOK_VERSION);
-    interlokProject.setVersion("3.11.1-RELEASE");
+    interlokProject.setVersion("4.0.0-RELEASE");
 
     new InterlokInstaller().install(interlokProject,
         p -> {},

--- a/src/test/java/com/adaptris/installer/helpers/InterlokInstallerTest.java
+++ b/src/test/java/com/adaptris/installer/helpers/InterlokInstallerTest.java
@@ -22,9 +22,7 @@ public class InterlokInstallerTest {
     InterlokProject interlokProject = new InterlokProject();
     interlokProject.setOptionalComponents(Collections.singletonList(TestUtils.buildOptionalComponent()));
     interlokProject.setDirectory(interlokProjectPath.toAbsolutePath().toString());
-    // We can use this line when we get a 4.0.0-RELEASE version
-    // interlokProject.setVersion(TestUtils.INTERLOK_VERSION);
-    interlokProject.setVersion("4.0.0-RELEASE");
+    interlokProject.setVersion(TestUtils.INTERLOK_VERSION);
 
     new InterlokInstaller().install(interlokProject,
         p -> {},


### PR DESCRIPTION
## Motivation

When using the installer on Mac and potentially on Linux, the start-interlok bash script installed with Interlok is not executable by default so the user need to do `chmod -x ./start-interlok` which is not ideal.

## Modification

The build.gradle.template used by the installer check if the OS is a not windows and in that case add the executable permission to the start-interlok script.

## PR Checklist

- [x] been self-reviewed.
- [x] Checked that new 3rd party dependencies are appropriately licensed
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader

## Result

The installer should work the same but the `bin/start-interlok` script should be executable after the installation of Interlok.

## Testing

Well, ideally with a Mac.

Build the tar or uber jar file for Mac on this PR's branch:

Tar:
`./gradlew clean assemble -PtargetPlatform=mac`

Uber Jar:
`./gradlew clean uberJar -PtargetPlatform=mac`

Launch the installer and install interlok.
Once installed, the bash script `bin/start-interlok` should be executable.



