### PR TITLE
INTERLOK-3807 #comment Upgrade the build.gradle of the installer proj…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
   id "jacoco"
   id "maven-publish"
   id "org.openjfx.javafxplugin" version "0.0.10"
-  id 'org.owasp.dependencycheck' version '6.2.2'
+  id 'org.owasp.dependencycheck' version "6.2.2"
 }
 
 ext {
@@ -30,7 +30,7 @@ ext {
   organizationName = "Adaptris Ltd"
   organizationUrl = "http://interlok.adaptris.net"
   javafxVersion = "11.0.2"
-  junitJupiterVersion = '5.7.2'
+  junitJupiterVersion = "5.7.2"
 }
 
 repositories {
@@ -41,7 +41,7 @@ repositories {
 }
 
 dependencies {
-  implementation "org.gradle:gradle-tooling-api:5.6.4"
+  implementation "org.gradle:gradle-tooling-api:7.1.1"
 
   runtimeOnly "org.openjfx:javafx-base:$javafxVersion:$targetPlatform"
   runtimeOnly "org.openjfx:javafx-graphics:$javafxVersion:$targetPlatform"
@@ -82,7 +82,7 @@ task uberJar(type: Jar) {
     attributes "Main-Class": mainClassName
   }
   // Build a uber jar
-  classifier = targetPlatform
+  archiveClassifier = targetPlatform
   from {
     configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
   }
@@ -91,7 +91,7 @@ task uberJar(type: Jar) {
 
 distributions {
   installer {
-    baseName = "$project.name-$targetPlatform"
+    distributionBaseName = "$project.name-$targetPlatform"
     contents {
       with distributions.main.contents
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/resources/templates/build.gradle.template
+++ b/src/main/resources/templates/build.gradle.template
@@ -3,7 +3,7 @@ plugins {
 }
 
 ext {
-  interlokVersion = project.hasProperty("interlokVersion") ? project.getProperty("interlokVersion") : "NEED interlokVersion PROPERTY"
+  interlokVersion = project.findProperty("interlokVersion") ?: "NEED interlokVersion PROPERTY"
   interlokUiVersion = interlokVersion
 
   interlokParentGradle = "https://raw.githubusercontent.com/adaptris-labs/interlok-build-parent/1.6.0/build.gradle"


### PR DESCRIPTION
…ect and the build gradle template used by the installer to gradle 7

## Motivation

The installer was using gradle 5.x and could not be used by java 13+ and also all the interlok projects have been updated to use gradle 7 and the new recommendation when using gradle parent is to use gradle 7.

## Modification

- Upgrade build.gradle to gradle 7
- Upgrade build.gradle.template used by the installer to gradle 7

## PR Checklist

- [x] been self-reviewed.

## Result

There is no changes if you're using java 11 but the installer will now work if you are using java 13+

## Testing

Build an installer using this branch:
`./gradlew clean assemble -PtargetPlatform=(win|linux|mac)`

Launch the installer with java11 and install some optional components.
Make sure it worked.
Do the same with java13
