### PR TITLE
INTERLOK-3802 Update installer to use latest interlok parent builder and base filesystem with no UI

### DIFF
--- a/src/main/java/com/adaptris/installer/InstallerDataHolder.java
+++ b/src/main/java/com/adaptris/installer/InstallerDataHolder.java
@@ -69,6 +69,7 @@ public class InstallerDataHolder {
     InterlokProject interlokProject = new InterlokProject();
     interlokProject.setVersion(getVersion());
     interlokProject.setDirectory(getInstallDir());
+    interlokProject.setIncludeWar(true);
     interlokProject.setAdditionalNexusBaseUrl(getAdditionalNexusBaseUrl());
     interlokProject.setOptionalComponents(getSelectedOptionalComponents());
     return interlokProject;

--- a/src/main/java/com/adaptris/installer/helpers/BuildGradleFileGenerator.java
+++ b/src/main/java/com/adaptris/installer/helpers/BuildGradleFileGenerator.java
@@ -69,7 +69,8 @@ public class BuildGradleFileGenerator {
 
     // TODO Use better template engine
     createBuildGradleFile(interlokProject.getOptionalComponents(), BUILD_GRADLE_TEMPLATE, destDir);
-    createGradlePropertiesFile(interlokProject.getVersion(), interlokProject.getDirectory(), interlokProject.getAdditionalNexusBaseUrl(), destDir);
+    createGradlePropertiesFile(interlokProject.getVersion(), interlokProject.getDirectory(), interlokProject.includeWar(),
+        interlokProject.getAdditionalNexusBaseUrl(), destDir);
 
     return destDir;
   }
@@ -113,7 +114,8 @@ public class BuildGradleFileGenerator {
     Files.writeString(buildGradlePath, buildGradleContent);
   }
 
-  private void createGradlePropertiesFile(String interlokVersion, String interlokDistDirectory, String additionalNexusBaseUrl,
+  private void createGradlePropertiesFile(String interlokVersion, String interlokDistDirectory, String includeWar,
+      String additionalNexusBaseUrl,
       Path destDirPath)
           throws IOException {
     Path gradlePropertiesPath = destDirPath.resolve(GRADLE_PROPERTIES);
@@ -124,7 +126,7 @@ public class BuildGradleFileGenerator {
     if (StringUtils.isNotBlank(additionalNexusBaseUrl)) {
       properties.put(ADDITIONAL_NEXUS_BASE_URL, additionalNexusBaseUrl);
     }
-    properties.put(INCLUDE_WAR, "true");
+    properties.put(INCLUDE_WAR, includeWar);
     Optional<String> baseUrl =
         BASE_URL_PARSERS.stream().map((p) -> p.build(interlokVersion)).filter((o) -> o.isPresent()).findFirst()
         .orElse(Optional.empty());

--- a/src/main/java/com/adaptris/installer/helpers/BuildGradleFileGenerator.java
+++ b/src/main/java/com/adaptris/installer/helpers/BuildGradleFileGenerator.java
@@ -32,6 +32,7 @@ public class BuildGradleFileGenerator {
   protected static final String INTERLOK_DIST_DIRECTORY = "interlokDistDirectory";
   protected static final String INTERLOK_BASE_FILESYSTEM_URL = "interlokBaseFilesystemUrl";
   protected static final String ADDITIONAL_NEXUS_BASE_URL = "additionalNexusBaseUrl";
+  protected static final String INCLUDE_WAR = "includeWar";
 
   private static final String INTERLOK_INSTALLER_TMP_DIR = "interlok-installer-tmp-";
   private static final String BUILD_GRADLE_TEMPLATE = "/templates/build.gradle.template";
@@ -123,6 +124,7 @@ public class BuildGradleFileGenerator {
     if (StringUtils.isNotBlank(additionalNexusBaseUrl)) {
       properties.put(ADDITIONAL_NEXUS_BASE_URL, additionalNexusBaseUrl);
     }
+    properties.put(INCLUDE_WAR, "true");
     Optional<String> baseUrl =
         BASE_URL_PARSERS.stream().map((p) -> p.build(interlokVersion)).filter((o) -> o.isPresent()).findFirst()
         .orElse(Optional.empty());

--- a/src/main/java/com/adaptris/installer/models/InterlokProject.java
+++ b/src/main/java/com/adaptris/installer/models/InterlokProject.java
@@ -8,6 +8,7 @@ public class InterlokProject {
   private List<OptionalComponent> optionalComponents = new ArrayList<>();
   private String directory;
   private String version;
+  private boolean includeWar;
   private String additionalNexusBaseUrl;
 
   public List<OptionalComponent> getOptionalComponents() {
@@ -33,6 +34,18 @@ public class InterlokProject {
 
   public void setVersion(String version) {
     this.version = version;
+  }
+
+  public boolean getIncludeWar() {
+    return includeWar;
+  }
+
+  public void setIncludeWar(boolean includeWar) {
+    this.includeWar = includeWar;
+  }
+
+  public String includeWar() {
+    return String.valueOf(includeWar);
   }
 
   public String getAdditionalNexusBaseUrl() {

--- a/src/main/resources/installer.properties
+++ b/src/main/resources/installer.properties
@@ -29,6 +29,6 @@ artifact.project.properties.xpath=/project/properties
 
 artifact.unwanted=interlok,adapter-web-gui,adp-core,interlok-core,adp-core-apt,interlok-core-apt,interlok-boot,jaxrs-client-proxy,interlok-client,interlok-client-jmx,interlok-common,interlok-logging,adp-sonicmf,interlok-sonicmf,interlok-ui-swagger-codegen,interlok-installer,interlok-jmx-jms-stubs,interlok-licensing-demo,interlok-stubs
 
-snapshot.filesystem.url=https://development.adaptris.net/nightly_builds/v4.x/${today}/base-filesystem.zip
+snapshot.filesystem.url=https://development.adaptris.net/nightly_builds/v4.x/${today}/base-filesystem-no-ui.zip
 release.filesystem.url=https://development.adaptris.net/installers/interlok/${release}/base-filesystem.zip
 beta.filesystem.url=https://development.adaptris.net/installers/early_access/${release}/base-filesystem.zip

--- a/src/main/resources/installer.properties
+++ b/src/main/resources/installer.properties
@@ -30,5 +30,5 @@ artifact.project.properties.xpath=/project/properties
 artifact.unwanted=interlok,adapter-web-gui,adp-core,interlok-core,adp-core-apt,interlok-core-apt,interlok-boot,jaxrs-client-proxy,interlok-client,interlok-client-jmx,interlok-common,interlok-logging,adp-sonicmf,interlok-sonicmf,interlok-ui-swagger-codegen,interlok-installer,interlok-jmx-jms-stubs,interlok-licensing-demo,interlok-stubs
 
 snapshot.filesystem.url=https://development.adaptris.net/nightly_builds/v4.x/${today}/base-filesystem-no-ui.zip
-release.filesystem.url=https://development.adaptris.net/installers/interlok/${release}/base-filesystem.zip
-beta.filesystem.url=https://development.adaptris.net/installers/early_access/${release}/base-filesystem.zip
+release.filesystem.url=https://development.adaptris.net/installers/interlok/${release}/base-filesystem-no-ui.zip
+beta.filesystem.url=https://development.adaptris.net/installers/early_access/${release}/base-filesystem-no-ui.zip

--- a/src/main/resources/templates/build.gradle.template
+++ b/src/main/resources/templates/build.gradle.template
@@ -8,7 +8,7 @@ ext {
 
   interlokParentGradle = "https://raw.githubusercontent.com/adaptris/interlok-build-parent/main/v4/build.gradle"
 
-  latestBaseFilesystemUrl = "https://development.adaptris.net/installers/interlok/latest-stable/base-filesystem.zip"
+  latestBaseFilesystemUrl = "https://development.adaptris.net/installers/interlok/latest-stable/base-filesystem-no-ui.zip"
   interlokBaseFilesystemUrl = project.findProperty("interlokBaseFilesystemUrl") ?: latestBaseFilesystemUrl
 
   additionalNexusBaseUrl = project.findProperty("additionalNexusBaseUrl") ?: ""

--- a/src/main/resources/templates/build.gradle.template
+++ b/src/main/resources/templates/build.gradle.template
@@ -40,17 +40,18 @@ task downloadBaseFilesystemZip(type: Download) {
   dest new File(buildDir, "base-filesystem.zip")
 }
 
-// This will override the war file
+// This will copy the config, bin, ui-resoures and webapps dirs
 task downloadAndUnzipFile(dependsOn: downloadBaseFilesystemZip, type: Copy) {
   from zipTree(downloadBaseFilesystemZip.dest)
   into file(srcInterlokDir)
 }
 
-// Do we need that or the previous step is enough?
 task downloadAndUnzipFileAndCopyConfigDir(dependsOn: downloadAndUnzipFile, type: Copy) {
+  // Do we need that or the previous step is enough?
   from file(srcInterlokDir + "config/")
   into interlokTmpConfigDirectory
-
+  
+  // Add execute permission to start-interlok bash file
   doLast {
     ant.chmod(file: "$srcInterlokDir/bin/start-interlok", perm: "+x")
   }

--- a/src/main/resources/templates/build.gradle.template
+++ b/src/main/resources/templates/build.gradle.template
@@ -6,7 +6,7 @@ ext {
   interlokVersion = project.findProperty("interlokVersion") ?: "NEED interlokVersion PROPERTY"
   interlokUiVersion = interlokVersion
 
-  interlokParentGradle = "https://raw.githubusercontent.com/adaptris/interlok-build-parent/main/v4/build.gradle"
+  interlokParentGradle = "https://raw.githubusercontent.com/adaptris/interlok-build-parent/1.8.0/v4/build.gradle"
 
   latestBaseFilesystemUrl = "https://development.adaptris.net/installers/interlok/latest-stable/base-filesystem-no-ui.zip"
   interlokBaseFilesystemUrl = project.findProperty("interlokBaseFilesystemUrl") ?: latestBaseFilesystemUrl

--- a/src/main/resources/templates/build.gradle.template
+++ b/src/main/resources/templates/build.gradle.template
@@ -6,7 +6,7 @@ ext {
   interlokVersion = project.findProperty("interlokVersion") ?: "NEED interlokVersion PROPERTY"
   interlokUiVersion = interlokVersion
 
-  interlokParentGradle = "https://raw.githubusercontent.com/adaptris-labs/interlok-build-parent/1.6.0/build.gradle"
+  interlokParentGradle = "https://raw.githubusercontent.com/adaptris/interlok-build-parent/main/v4/build.gradle"
 
   latestBaseFilesystemUrl = "https://development.adaptris.net/installers/interlok/latest-stable/base-filesystem.zip"
   interlokBaseFilesystemUrl = project.findProperty("interlokBaseFilesystemUrl") ?: latestBaseFilesystemUrl

--- a/src/test/java/com/adaptris/installer/model/InterlokProjectTest.java
+++ b/src/test/java/com/adaptris/installer/model/InterlokProjectTest.java
@@ -1,6 +1,7 @@
 package com.adaptris.installer.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collections;
 
@@ -28,6 +29,13 @@ public class InterlokProjectTest {
     assertEquals("/path/to/interlok", interlokProjectTest.getDirectory());
   }
 
+  @Test
+  public void testIncludeWar() {
+    interlokProjectTest.setIncludeWar(true);
+
+    assertTrue(interlokProjectTest.getIncludeWar());
+    assertEquals("true", interlokProjectTest.includeWar());
+  }
   @Test
   public void testAdditionalNexusBaseUrl() {
     interlokProjectTest.setAdditionalNexusBaseUrl("https://nexus.adaptris.net");


### PR DESCRIPTION
## Motivation

The installer was using an old version of interlok parent builder so we needed to use the latest one on github adaptris.
The installer was also using base-filesystem.zip with a ui war file in it but it's more efficient to download the UI war file via gradle.

## Modification

- Tag the latest interlok build parent with 1.8.0: https://raw.githubusercontent.com/adaptris/interlok-build-parent/1.8.0/v4/build.gradle
- Change the installer code to use that new version of the interlok build parent
- Change the installer to download the war file via gradle (new property: includeWar=true)
- Added a new base-filesystem-no-ui.zip file in the pipeline and release process
- Change the installer to use ase-filesystem-no-ui.zip instead of ase-filesystem.zip
- Updated tests

## PR Checklist

- [x] been self-reviewed.

## Result

The installer should work the same way for the user but it should be a bit faster as the ui war download is managed by gradle.

## Testing

Build an installer from this branch with `gradlew clean assemble -PtargetPlatform=win`
Start the installer and install a few optional components
When the install is successful download the gradle files and open build.gradle in the zip file
Make sure `interlokParentGradle = "https://raw.githubusercontent.com/adaptris/interlok-build-parent/1.8.0/v4/build.gradle"`
Make sure `latestBaseFilesystemUrl = "https://development.adaptris.net/installers/interlok/latest-stable/base-filesystem-no-ui.zip"`
Open gradle.properties
Make sure `interlokBaseFilesystemUrl=https\://development.adaptris.net/nightly_builds/v4.x/2021-08-12/base-filesystem-no-ui.zip`
Verify that those components have been installed correctly
Verify that the war file is in the webapps folder
Verify that Interlok and the UI starts correctly
