### PR TITLE
Feature/interlok 3840 garbled chars on mac os big sur

### DIFF
--- a/src/main/resources/css/style.css
+++ b/src/main/resources/css/style.css
@@ -3,6 +3,7 @@
     -fx-background-repeat: no-repeat;
     -fx-background-size: 103%;
     -fx-background-position: 0;
+    -fx-font-family: "Helvetica", "Arial", "sans-serif";
 }
 
 .page-logo {


### PR DESCRIPTION
## Motivation

A user had an issue when running the installer on MacOS Big Sur (11.5.2),the UI text is jumbled (the output is attached).  I am on macOS Big Sur (11.5.2).

The java version is:
java 11.0.12 2021-07-20 LTS
Java(TM) SE Runtime Environment 18.9 (build 11.0.12+8-LTS-237)
Java HotSpot(TM) 64-Bit Server VM 18.9 (build 11.0.12+8-LTS-237, mixed mode)

## Modification

Explicitly set some fonts to the whole JavaFx app so hopefully MacOS Big Sur won't try to use the system font and fail.

## PR Checklist

- [x] been self-reviewed.

## Result

The installer text should be displayed nicely

## Testing

Build the installer from this branch for windows, mac and linux
`
./gradlew clean uberJar -PtargetPlatform=win
./gradlew clean uberJar -PtargetPlatform=mac
./gradlew clean uberJar -PtargetPlatform=linux
`
Start it and test it to see if the text display nicely.
`java -jar ./build/libs/interlok-installer-(version)-(win|linux|mac).jar`

