### PR TITLE
INTERLOK-3933 Use the new base filesystem zip from nexus.

### DIFF
--- a/src/main/java/com/adaptris/installer/helpers/BuildGradleFileGenerator.java
+++ b/src/main/java/com/adaptris/installer/helpers/BuildGradleFileGenerator.java
@@ -7,9 +7,7 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.time.LocalDate;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
@@ -21,7 +19,6 @@ import org.gradle.internal.impldep.org.apache.commons.lang.StringUtils;
 import com.adaptris.installer.models.InterlokProject;
 import com.adaptris.installer.models.OptionalComponent;
 import com.adaptris.installer.utils.ResourceUtils;
-import com.adaptris.installer.utils.VersionUtils;
 import com.adaptris.installer.utils.ZipUtils;
 
 public class BuildGradleFileGenerator {
@@ -40,20 +37,10 @@ public class BuildGradleFileGenerator {
   private static final String ZIP = ".zip";
   private static final String INDENT = "  ";
 
-  private static final String INSTALLER_PROPERTY_SNAPSHOT_FILESYSTEM_URL = "snapshot.filesystem.url";
-  private static final String INSTALLER_PROPERTY_BETA_FILESYSTEM_URL = "beta.filesystem.url";
-  private static final String INSTALLER_PROPERTY_RELEASE_FILESYSTEM_URL = "release.filesystem.url";
+  private static final String INSTALLER_PROPERTY_FILESYSTEM_URL = "filesystem.url";
 
   private final Path tmpDirPath;
   private final InstallerProperties installerProperties;
-
-  private final List<BaseFilesystemBuilder> BASE_URL_PARSERS =
-      Collections.unmodifiableList(
-          Arrays.asList(new BaseFilesystemBuilder[] {
-              (interlokVersion) -> snapshotUrl(interlokVersion),
-              (interlokVersion) -> betaUrl(interlokVersion),
-              (interlokVersion) -> releaseUrl(interlokVersion)
-          }));
 
   public BuildGradleFileGenerator() {
     this(Paths.get(System.getProperty("java.io.tmpdir")));
@@ -127,36 +114,15 @@ public class BuildGradleFileGenerator {
       properties.put(ADDITIONAL_NEXUS_BASE_URL, additionalNexusBaseUrl);
     }
     properties.put(INCLUDE_WAR, includeWar);
-    Optional<String> baseUrl =
-        BASE_URL_PARSERS.stream().map((p) -> p.build(interlokVersion)).filter((o) -> o.isPresent()).findFirst()
-        .orElse(Optional.empty());
-    baseUrl.ifPresent((val) -> properties.put(INTERLOK_BASE_FILESYSTEM_URL, val));
+    baseUrl().ifPresent((val) -> properties.put(INTERLOK_BASE_FILESYSTEM_URL, val));
 
     try (OutputStream outputStream = Files.newOutputStream(gradlePropertiesPath)) {
       properties.store(outputStream, "");
     }
   }
 
-  private Optional<String> betaUrl(String interlokVersion) {
-    if (VersionUtils.isBeta(interlokVersion)) {
-      String rawVersion = interlokVersion.replace("-RELEASE", "");
-      return Optional.of(installerProperties.getProperty(INSTALLER_PROPERTY_BETA_FILESYSTEM_URL).replace("${release}", rawVersion));
-    }
-    return Optional.empty();
-  }
-
-  private Optional<String> snapshotUrl(String interlokVersion) {
-    if (VersionUtils.isSnapshot(interlokVersion)) {
-      return Optional.of(installerProperties.getProperty(INSTALLER_PROPERTY_SNAPSHOT_FILESYSTEM_URL).replace("${today}",
-          LocalDate.now().minusDays(1).toString()));
-    }
-    return Optional.empty();
-  }
-
-  private Optional<String> releaseUrl(String interlokVersion) {
-    String rawVersion = interlokVersion.replace("-RELEASE", "");
-    return Optional
-        .of(installerProperties.getProperty(INSTALLER_PROPERTY_RELEASE_FILESYSTEM_URL).replace("${release}", rawVersion));
+  private Optional<String> baseUrl() {
+    return Optional.of(installerProperties.getProperty(INSTALLER_PROPERTY_FILESYSTEM_URL));
   }
 
   private String toLinesString(List<OptionalComponent> optionalComponents, Function<OptionalComponent, String> func) {

--- a/src/main/resources/installer.properties
+++ b/src/main/resources/installer.properties
@@ -27,8 +27,6 @@ artifact.project.description.xpath=/project/description
 artifact.project.url.xpath=/project/url
 artifact.project.properties.xpath=/project/properties
 
-artifact.unwanted=interlok,adapter-web-gui,adp-core,interlok-core,adp-core-apt,interlok-core-apt,interlok-boot,jaxrs-client-proxy,interlok-client,interlok-client-jmx,interlok-common,interlok-logging,adp-sonicmf,interlok-sonicmf,interlok-ui-swagger-codegen,interlok-installer,interlok-jmx-jms-stubs,interlok-licensing-demo,interlok-stubs
+artifact.unwanted=interlok,adapter-web-gui,adp-core,interlok-core,adp-core-apt,interlok-core-apt,interlok-boot,jaxrs-client-proxy,interlok-client,interlok-client-jmx,interlok-common,interlok-logging,adp-sonicmf,interlok-sonicmf,interlok-ui-swagger-codegen,interlok-installer,interlok-jmx-jms-stubs,interlok-licensing-demo,interlok-stubs,interlok-base-filesystem
 
-snapshot.filesystem.url=https://development.adaptris.net/nightly_builds/v4.x/${today}/base-filesystem-no-ui.zip
-release.filesystem.url=https://development.adaptris.net/installers/interlok/${release}/base-filesystem-no-ui.zip
-beta.filesystem.url=https://development.adaptris.net/installers/early_access/${release}/base-filesystem-no-ui.zip
+filesystem.url=https://nexus.adaptris.net/nexus/content/groups/interlok/com/adaptris/interlok-base-filesystem/1.0.0/interlok-base-filesystem-1.0.0.zip

--- a/src/main/resources/templates/build.gradle.template
+++ b/src/main/resources/templates/build.gradle.template
@@ -5,9 +5,9 @@ plugins {
 ext {
   interlokVersion = project.findProperty("interlokVersion") ?: "NEED interlokVersion PROPERTY"
 
-  interlokParentGradle = "https://raw.githubusercontent.com/adaptris/interlok-build-parent/1.8.10/v4/build.gradle"
+  interlokParentGradle = project.findProperty("interlokParentGradle") ?: "https://raw.githubusercontent.com/adaptris/interlok-build-parent/1.8.10/v4/build.gradle"
 
-  latestBaseFilesystemUrl = "https://development.adaptris.net/installers/interlok/latest-stable/base-filesystem-no-ui.zip"
+  latestBaseFilesystemUrl = "https://nexus.adaptris.net/nexus/content/groups/interlok/com/adaptris/interlok-base-filesystem/1.0.0/interlok-base-filesystem-1.0.0-with-templates.zip"
   interlokBaseFilesystemUrl = project.findProperty("interlokBaseFilesystemUrl") ?: latestBaseFilesystemUrl
 
   additionalNexusBaseUrl = project.findProperty("additionalNexusBaseUrl") ?: ""

--- a/src/test/java/com/adaptris/installer/helpers/InstallerPropertiesTest.java
+++ b/src/test/java/com/adaptris/installer/helpers/InstallerPropertiesTest.java
@@ -94,7 +94,7 @@ public class InstallerPropertiesTest {
   public void testGetProperties() {
     Properties properties = InstallerProperties.getInstance().getProperties();
     // Bit magic number, this is the number of properties we have atm.
-    assertEquals(20, properties.size());
+    assertEquals(18, properties.size());
   }
 
 }


### PR DESCRIPTION
## Motivation

We publish the base-filesystem zip artifact into nexus so we want to use it.

## Modification

- Use the new nexus url
- Remove some code as we always use the same version we don't need to check for snapshots, beta or release version anymore.

## PR Checklist

- [x] been self-reviewed.

## Result

It should work the same as before, just using a different url

## Testing

Build the installer from this branch and test that it works fine and that the install adapter has the proper dir structure.
