### PR TITLE
fix: update dependabot syntax to fix error

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 registries:
-  maven-github:
+  interlok:
     type: maven-repository
     url: https://nexus.adaptris.net/nexus/content/groups/interlok
     username: developer


### PR DESCRIPTION
## Motivation

Trying to work out why I'm still getting added to PRs I found that the dependabot CI is throwing an error. I'm assuming that this means the changes are not being applied which is why I'm being added.

Check can be found here: https://github.com/adaptris/interlok-installer/runs/14460511342

```text
The property '#/updates/0/registries' includes the "interlok" registry which is not defined in the top-level 'registries' definition
The property '#/updates/1/registries' includes the "interlok" registry which is not defined in the top-level 'registries' definition
```

## Modification

Fixed broken reference based on error.
